### PR TITLE
Update LSM9DS1_BasicAHRS_Nano33.ino

### DIFF
--- a/LSM9DS1_BasicAHRS_Nano33.ino
+++ b/LSM9DS1_BasicAHRS_Nano33.ino
@@ -431,7 +431,7 @@ void loop()
   // in the LSM9DS0 sensor. This rotation can be modified to allow any convenient orientation convention.
   // This is ok by aircraft orientation standards!  
   // Pass gyro rate as rad/s
-  MadgwickQuaternionUpdate(ax, ay, az, gx*PI/180.0f, gy*PI/180.0f, gz*PI/180.0f, -mx, -my, mz);
+  MadgwickQuaternionUpdate(ax, ay, az, gx*PI/180.0f, gy*PI/180.0f, gz*PI/180.0f, -mx, my, mz);
   //  MahonyQuaternionUpdate(ax, ay, az, gx*PI/180.0f, gy*PI/180.0f, gz*PI/180.0f, -mx, my, mz);
 
   // Serial print and/or display at 0.5 s rate independent of data rates


### PR DESCRIPTION
Bug fix: accidentally aligned the quaternion update with the negative of the magnetometer Y axis, leftover from my application specific need.